### PR TITLE
Ensemble weights via seeded initializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tests/testthat/*.pdf
 *.pyc
 */__pycache__
 *.cpython
+.Rproj.user

--- a/R/deep-ensembles.R
+++ b/R/deep-ensembles.R
@@ -238,11 +238,13 @@ reinit_weights.deepregression <- function(object, seed) {
   lapply(object$model$layers, function(x) {
     # x$build(x$input_shape)
     dtype <- x$dtype
-    dshape <- try(x$kernel$shape, silent = TRUE)
-    dweight <- try(x$kernel_initializer(shape = dshape, dtype = dtype,
-                                        seed = seed), silent = TRUE)
-    try(x$set_weights(weights = list(dweight)), silent = TRUE)
+    try({
+      dshape <- x$kernel$shape
+      dinit <- x$kernel_initializer$from_config(
+        config = list(seed = tf$constant(seed)))
+      dweight <- dinit(shape = dshape, dtype = dtype)
+      x$set_weights(weights = list(dweight))
+    }, silent = TRUE)
   })
-
   return(invisible(object))
 }

--- a/tests/testthat/test_ensemble.R
+++ b/tests/testthat/test_ensemble.R
@@ -16,7 +16,7 @@ test_that("deep ensemble", {
   )
 
   cf_init <- coef(mod)
-  ret <- ensemble(mod, epochs = 10, save_weights = TRUE)
+  ret <- ensemble(mod, epochs = 10, save_weights = TRUE, verbose = TRUE)
   cf_post <- coef(mod)
 
   expect_identical(cf_init, cf_post)
@@ -60,12 +60,15 @@ test_that("reinitializing weights", {
     )
   )
 
+  reinit_weights(mod, seed = 1)
   cfa <- coef(mod)
-  reinit_weights(mod)
+  reinit_weights(mod, seed = 2)
   cfb <- coef(mod)
 
+  expect_false(all(cfa[[1]] == cfb[[1]]))
+
   fit(mod, epochs = 2)
-  reinit_weights(mod)
+  reinit_weights(mod, seed = 3)
   fit(mod, epochs = 2)
 
   expect_identical(cfa$x1, cfb$x1)


### PR DESCRIPTION
New behavior of `tensorflow' requires instantiating and executing an initializer for reinitializing weights of an existing model