### PR TITLE
Fix for bug in `handle_gam_term`

### DIFF
--- a/R/psplinelayer.R
+++ b/R/psplinelayer.R
@@ -187,6 +187,7 @@ handle_gam_term <- function(
   # check for df argument and remove
   object <- remove_df_wrapper(object)
   names_s <- all.vars(as.formula(paste0("~", object)))
+  names_s <- names_s[names_s %in% names(data)]
   sterm <- smoothCon(eval(parse(text=object)),
                      data=data.frame(data[names_s]),
                      absorb.cons = controls$absorb_cons,


### PR DESCRIPTION
Running 
```
library(deepregression)
library(mgcv)

data(columb)
data(columb.polys)

xt <- list(polys = columb.polys)
m <- deepregression(y = columb$crime,
                    data = columb,
                    list_of_formulas = list(
                      ~ s(district, bs = "mrf", xt = xt),
                      ~ 1
                    ),
                    list_of_deep_models = NULL)
```
throws the error

> Error in (function (..., row.names = NULL, check.rows = FALSE, check.names = TRUE,  : 
>   arguments imply differing number of rows: 49, 0

The source of this problem is in `deepregression::handle_gam_term` 
```
handle_gam_term <- function(
  object,
  data,
  controls
)
{

  # check for df argument and remove
  object <- remove_df_wrapper(object)
  names_s <- all.vars(as.formula(paste0("~", object)))
  sterm <- smoothCon(eval(parse(text=object)),
                     data=data.frame(data[names_s]),
                     absorb.cons = controls$absorb_cons,
                     null.space.penalty = controls$null_space_penalty
  )
  # sterm <- controls$defaultSmoothing(sterm, df)
  return(sterm)

}
```
in which the error occurs because `data.frame(data[names_s])` fails if `data[names_s]` is a `list` containing `NULL` elements, which in turn happens if `names_s` (mistakenly) contains elements that are not contained in `names(data)`.  
 
In the example above, in the internal call to `deepregression::handle_gam_term` we have `object == "s(district,bs=\"mrf\",xt=xt)"` and `xt`  is therefore an element of `names_s` but there is no corresponding list element in `data`.  

I've suggested a quick fix for this in my pull request. Another option would be to pre-process `object` in way that `all.vars` doesn't mistakenly pick up object like `xt` when calling `all.vars(as.formula(paste0("~", object)))`. 